### PR TITLE
Use const when lifting auipc insn

### DIFF
--- a/lifter.py
+++ b/lifter.py
@@ -450,8 +450,7 @@ class Lifter:
         il.append(
             il.set_reg(
                 self.addr_size, op[0],
-                il.add(self.addr_size, il.reg(self.addr_size, 'pc'),
-                       il.const(self.addr_size, imm << 12))))
+                il.const(self.addr_size, il.current_address + (imm << 12))))
 
     def sd(self, il, op, imm):
         offset = il.add(self.addr_size, il.reg(self.addr_size, op[1]),


### PR DESCRIPTION
This is known at lifting time. With this change, `auipc`/`jalr` calls correctly get constpropagated.