### PR TITLE
Fix branch for compressed instruction (c.beqz, c.bnez)

### DIFF
--- a/riscv.py
+++ b/riscv.py
@@ -20,7 +20,7 @@ from .lifter import Lifter
 
 branch_ins = set([
     'beq', 'bne', 'beqz', 'bnez', 'bge', 'bgeu', 'blt', 'bltu', 'blez', 'bgez',
-    'bltz', 'bgtz'
+    'bltz', 'bgtz', 'c.bnez', 'c.beqz'
 ])
 
 direct_call_ins = set(['jal', 'j'])


### PR DESCRIPTION
I'm not into RISC-V but it seems like, according to the spec https://riscv.org/wp-content/uploads/2019/06/riscv-spec.pdf, there are only c.beqz and c.bnez for the branch instruction in compressed standard extension.