### PR TITLE
fix typo? in bgeu lifter (op[0] >= op[1])

### DIFF
--- a/lifter.py
+++ b/lifter.py
@@ -268,7 +268,7 @@ class Lifter:
     def bgeu(self, il, op, imm):
         cond = il.compare_unsigned_greater_equal(self.addr_size,
                                                  il.reg(self.addr_size, op[0]),
-                                                 il.reg(self.addr_size, op[0]))
+                                                 il.reg(self.addr_size, op[1]))
         self.condBranch(il, cond, imm)
 
     def blez(self, il, op, imm):


### PR DESCRIPTION
I think you have made a typo, it should be op[0] >= op[1]