### PR TITLE
fix lifting compressed loads and stores

### DIFF
--- a/lifter.py
+++ b/lifter.py
@@ -64,7 +64,8 @@ class Lifter:
                 # the same rule of thumb:
                 # inst rX, rX, P <=> c.inst rX, P
 
-                if ops:
+                # compressed loads and stores just use the same operands
+                if ops and mnemonic[2:] not in {'lw', 'ld', 'lq', 'sw', 'sd', 'sq'}:
                     ops = [ops[0]] + ops
 
         if handler is not None:


### PR DESCRIPTION
I haven't tested the stores properly, the loads definitely work. Noticed the bug on a mis-lift of `firmware.elf` from PCIVault 1 at Google CTF quals 2021.