### PR TITLE
Fix: lifting bugs

### DIFF
--- a/instruction.py
+++ b/instruction.py
@@ -102,22 +102,22 @@ class RVDisassembler:
                              imm_val)
 
 
-def gen_token(instr):
+def gen_token(instr: RVInstruction):
     tokens = [
         InstructionTextToken(InstructionTextTokenType.InstructionToken,
                              "{:6} ".format(instr.name))
     ]
     operands = instr.operands
 
-    for i in operands:
+    for i, reg in enumerate(operands):
         tokens.append(
-            InstructionTextToken(InstructionTextTokenType.TextToken, " "))
+            InstructionTextToken(InstructionTextTokenType.TextToken, " " if i == 0 else ", "))
         tokens.append(
-            InstructionTextToken(InstructionTextTokenType.RegisterToken, i))
+            InstructionTextToken(InstructionTextTokenType.RegisterToken, reg))
 
     if instr.imm_val:
         tokens.append(
-            InstructionTextToken(InstructionTextTokenType.TextToken, " "))
+            InstructionTextToken(InstructionTextTokenType.TextToken, ", "))
 
         if instr.name in _OFFSET:
             # val = instr.address + instr.imm

--- a/lifter.py
+++ b/lifter.py
@@ -834,6 +834,9 @@ class Lifter:
     def csrw(self, il, op, imm):
         il.append(il.set_reg(self.addr_size, op[0], il.undefined()))
 
+    def fence(self, il: LowLevelILFunction, op, imm):
+        il.append(il.intrinsic([], 'fence', []))
+
     def wfi(self, il: LowLevelILFunction, op, imm):
         il.append(il.intrinsic([], 'wfi', []))
 

--- a/lifter.py
+++ b/lifter.py
@@ -22,7 +22,7 @@ _unliftable = set()
 
 
 class Lifter:
-    def __init__(self, addr_size, arch_name='riscv'):
+    def __init__(self, addr_size, arch_name):
         self.arch_name = arch_name
         self.addr_size = addr_size
 

--- a/lifter.py
+++ b/lifter.py
@@ -411,6 +411,21 @@ class Lifter:
                 il.mult(self.addr_size, il.reg(self.addr_size, op[1]),
                         il.reg(self.addr_size, op[2]))))
 
+    def mulh(self, il, op, imm):
+        il.append(
+            il.set_reg(
+                self.addr_size, op[0],
+                il.logical_shift_right(self.addr_size,
+                    il.mult(self.addr_size * 2, il.reg(self.addr_size, op[1]),
+                        il.reg(self.addr_size, op[2])),
+                    il.const(1, self.addr_size * 8))))
+
+    def mulhu(self, il, op, imm):
+        self.mulh(il, op, imm)
+
+    def mulhsu(self, il, op, imm):
+        self.mulh(il, op, imm)
+
     def div(self, il, op, imm):
         il.append(
             il.set_reg(

--- a/lifter.py
+++ b/lifter.py
@@ -840,6 +840,12 @@ class Lifter:
     def wfi(self, il: LowLevelILFunction, op, imm):
         il.append(il.intrinsic([], 'wfi', []))
 
+    def mret(self, il: LowLevelILFunction, op, imm):
+        il.append(il.ret(il.reg(self.addr_size, 'mepc')))
+
+    def sret(self, il: LowLevelILFunction, op, imm):
+        il.append(il.ret(il.reg(self.addr_size, 'sepc')))
+
     # floating point instructions
 
     def flw(self, il, op, imm):

--- a/lifter.py
+++ b/lifter.py
@@ -621,15 +621,19 @@ class Lifter:
                                          il.const(1, imm)))))
 
     def lui(self, il, op, imm):
+        # Set the immediate up as a 32-bit constant, w/ the constant value in the upper 20 bits
+        imm = il.shift_left(4,
+            il.const(3, imm),
+            il.const(1, 12))
+        # If we're decoding RISC-V 64, also zero-extend to the full register width
+        if self.addr_size == 8:
+            imm = il.zero_extend(self.addr_size, imm)
+
         il.append(
             il.set_reg(
                 self.addr_size,
                 op[0],
-                # il.shift_left(self.addr_size,
-                #               il.zero_extend(self.addr_size, il.const(3, imm)),
-                #               # il.const(self.addr_size, imm)),
-                #               il.const(self.addr_size, 12))
-                il.const(self.addr_size, imm)))
+                imm))
 
     def c_li(self, il, op, imm):
         il.append(

--- a/lifter.py
+++ b/lifter.py
@@ -834,6 +834,9 @@ class Lifter:
     def csrw(self, il, op, imm):
         il.append(il.set_reg(self.addr_size, op[0], il.undefined()))
 
+    def wfi(self, il: LowLevelILFunction, op, imm):
+        il.append(il.intrinsic([], 'wfi', []))
+
     # floating point instructions
 
     def flw(self, il, op, imm):

--- a/riscv.py
+++ b/riscv.py
@@ -141,6 +141,7 @@ class RISCV(Architecture):
 
     intrinsics = {
         'wfi': IntrinsicInfo([], []),
+        'fence': IntrinsicInfo([], []),
     }
 
     def get_instruction_info(self, data, addr):

--- a/riscv.py
+++ b/riscv.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 
 from binaryninja import (Architecture, BranchType, Endianness, InstructionInfo,
-                         RegisterInfo)
+                         RegisterInfo, IntrinsicInfo)
 
 from .instruction import RVDisassembler, gen_token
 from .lifter import Lifter
@@ -138,6 +138,10 @@ class RISCV(Architecture):
     }
 
     stack_pointer = "sp"
+
+    intrinsics = {
+        'wfi': IntrinsicInfo([], []),
+    }
 
     def get_instruction_info(self, data, addr):
 

--- a/riscv.py
+++ b/riscv.py
@@ -96,6 +96,10 @@ class RISCV(Architecture):
         "t6": RegisterInfo("t6", address_size),
         # pc (caller saved)
         "pc": RegisterInfo("pc", address_size),
+        # machine CSRs
+        "mepc": RegisterInfo("mepc", address_size),
+        # supervisor CSRs
+        "sepc": RegisterInfo("sepc", address_size),
 
         # f0-7 - FP temporaries (caller saved)
         "ft0": RegisterInfo("ft0", default_float_size),

--- a/riscv.py
+++ b/riscv.py
@@ -45,7 +45,7 @@ class RISCV(Architecture):
     endianness = Endianness.LittleEndian
 
     disassembler = RVDisassembler(address_size)
-    lifter = Lifter(address_size)
+    lifter = Lifter(address_size, arch_name = name)
 
     # we are using the ABI names here, as those are also the register names
     # returned by capstone.
@@ -220,7 +220,7 @@ class RISCV64(RISCV):
     default_int_size = 4
 
     disassembler = RVDisassembler(address_size)
-    lifter = Lifter(address_size)
+    lifter = Lifter(address_size, arch_name = name)
 
     regs = {
         k: (RegisterInfo(k, 8) if v.size == 4 else RegisterInfo(k, v.size))


### PR DESCRIPTION
While working on figuring out how a ROM in a RISC-V MCU works the last week and a bit, we ran into several issues with the plugin's lifting of RISC-V assembly to LLIL.

This PR is the culmination of that work, including fixing `mret` and `sret` returns, and `lui` decoding for both RV32 and RV64. We've also fixed high multiplication handling and added support for lifting the WFI intrinsic - though there are certainly more we could implement, including the entire privileged spec CSR space.

If lifting of the CSR space and other parts of the privileged spec is of interest, then we would be up for doing a follow-up PR to do more work in this area.